### PR TITLE
Fix and improve the minimum order quantity, attrition and pricing.

### DIFF
--- a/contrib/details-by-part.php
+++ b/contrib/details-by-part.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * details-by-part.php
+ *
+ * This script fetches component information from the JLCPCB API
+ * based on a part number provided in the URL query string.
+ *
+ * Usage example:
+ * http://your-server.com/details-by-part.php?partNumber=C10002
+ *
+ * It acts as a server-side proxy to bypass potential CORS issues
+ * and provides a simple way to get component data.
+ */
+
+  function cors() {
+    
+    // Allow from any origin
+    if (isset($_SERVER['HTTP_ORIGIN'])) {
+        // Decide if the origin in $_SERVER['HTTP_ORIGIN'] is one
+        // you want to allow, and if so:
+        header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
+        header('Access-Control-Allow-Credentials: true');
+        header('Access-Control-Max-Age: 86400');    // cache for 1 day
+    }
+    
+    // Access-Control headers are received during OPTIONS requests
+    if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+        
+        if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
+            // may also be using PUT, PATCH, HEAD etc
+            header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+        
+        if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
+            header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
+    
+        exit(0);
+    }
+    
+   //  echo "You have CORS!";
+  }
+
+  cors();
+
+  // Check if the 'partNumber' query string parameter is set.
+  if (!isset($_GET['partNumber'])) 
+  {
+      http_response_code(400); // Bad Request
+      echo json_encode(['error' => 'The "partNumber" query string parameter is required.']);
+      exit;
+  }
+
+  function search_for_part($partNumber)
+  {
+    // Which of these searches that the part number shows up in, is indeterminate!    
+    foreach(['stock','buy','post', ''] as $presaleType)
+    {
+      // Define the API endpoint URL.
+      $url = 'https://jlcpcb.com/api/overseas-pcb-order/v1/shoppingCart/smtGood/selectSmtComponentList/v2';
+
+      // Define the request headers as an array.
+      $headers = [
+          'authority: jlcpcb.com',
+          'accept: application/json, text/plain, */*',
+          'accept-language: en-US,en;q=0.9',
+          'cache-control: no-cache',
+          'content-type: application/json',
+          'origin: https://jlcpcb.com',
+          'pragma: no-cache',
+          'referer: https://jlcpcb.com/parts',
+          'sec-ch-ua: "Chromium";v="104", " Not A;Brand";v="99", "Google Chrome";v="104"',
+          'sec-ch-ua-mobile: ?0',
+          'sec-ch-ua-platform: "Linux"',
+          'sec-fetch-dest: empty',
+          'sec-fetch-mode: cors',
+          'sec-fetch-site: same-origin',
+          'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
+      ];
+
+      // Create the JSON payload for the POST request.
+      $postData = [
+          'componentLibraryType' => null,
+          'currentPage' => 1,
+          'firstSortName' => null,
+          'keyword' => $partNumber, // Insert the part number here.
+          'pageSize' => 25,
+          'presaleType' => $presaleType,
+          'searchType' => 2,
+          'secondSortName' => null,
+          'stockFlag' => null,
+          'stockSort' => null,
+      ];
+
+      // Encode the payload into a JSON string.
+      $jsonPostData = json_encode($postData);
+
+
+      // Initialize cURL session.
+      $curl = curl_init();
+
+      // Set the cURL options.
+      curl_setopt_array($curl, [
+          CURLOPT_URL => $url,
+          CURLOPT_RETURNTRANSFER => true, // Return the response as a string instead of echoing it.
+          CURLOPT_POST => true,           // Set the request method to POST.
+          CURLOPT_POSTFIELDS => $jsonPostData, // Set the POST data.
+          CURLOPT_HTTPHEADER => $headers, // Set the request headers.
+          CURLOPT_ENCODING => '', // Handles all encodings.
+          CURLOPT_MAXREDIRS => 10,
+          CURLOPT_TIMEOUT => 30,
+          CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+          CURLOPT_CUSTOMREQUEST => 'POST'
+      ]);
+
+      // Execute the cURL request.
+      $response = curl_exec($curl);
+      
+
+      // Check for errors.
+      if (curl_errno($curl)) {
+        curl_close($curl);
+          return ['code' => 500, 'error' => 'cURL error: ' . curl_error($curl)];
+      } else {
+        curl_close($curl);
+        // Search through the results to see if the part number is in there
+        $r = json_decode($response, TRUE);
+        
+        if($r['code'] !== 200) 
+        {
+          if(!$r['error']) $r['error'] = 'Unknown Error from JLC';
+          return $r;
+        }
+        
+        if(@$r['data']['componentPageInfo']['total']>=1)
+        {
+          foreach($r['data']['componentPageInfo']['list'] as $component)
+          {
+            if($component['componentCode'] === $partNumber)
+            {
+              // Found
+              return $component;
+            }
+          }
+        }
+      }
+    }
+      
+    return ['code' => 404, 'error' => 'Not Found'];
+  }
+
+  function get_pricing_data($componentLcscId)
+  {
+    // Define the API endpoint URL.
+    $url = 'https://jlcpcb.com/api/overseas-pcb-order/v1/shoppingCart/smtGood/getComponentDetail?componentLcscId='.$componentLcscId;
+
+    // Define the request headers as an array.
+    $headers = [
+        'authority: jlcpcb.com',
+        'accept: application/json, text/plain, */*',
+        'accept-language: en-US,en;q=0.9',
+        'cache-control: no-cache',
+        'content-type: application/json',
+        'origin: https://jlcpcb.com',
+        'pragma: no-cache',
+        'referer: https://jlcpcb.com/parts',
+        'sec-ch-ua: "Chromium";v="104", " Not A;Brand";v="99", "Google Chrome";v="104"',
+        'sec-ch-ua-mobile: ?0',
+        'sec-ch-ua-platform: "Linux"',
+        'sec-fetch-dest: empty',
+        'sec-fetch-mode: cors',
+        'sec-fetch-site: same-origin',
+        'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36',
+    ];
+
+    // Initialize cURL session.
+    $curl = curl_init();
+
+    // Set the cURL options.
+    curl_setopt_array($curl, [
+        CURLOPT_URL => $url,
+        CURLOPT_RETURNTRANSFER => true, // Return the response as a string instead of echoing it.
+        CURLOPT_HTTPHEADER => $headers, // Set the request headers.
+        CURLOPT_ENCODING => '', // Handles all encodings.
+        CURLOPT_MAXREDIRS => 10,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+    ]);
+
+    // Execute the cURL request.
+    $response = curl_exec($curl);
+
+    // Check for errors.
+    if (curl_errno($curl)) {
+        curl_close($curl);
+        return ['code' => 500, 'error' => 'cURL error: ' . curl_error($curl)];
+    } else {
+        $r = json_decode($response, true);
+        if($r['code'] !== 200) 
+        {
+          if(!$r['error']) $r['error'] = 'Unknown Error from JLC';
+          return $r;
+        }
+        
+        return $r['data'];
+        
+    }
+    
+    return ['code' => 404, 'error' => 'Pricing data not found'];
+  }
+  
+  
+  header('Content-Type: application/json');
+  
+  $component = search_for_part($_GET['partNumber']);
+  if(@$component['error'])
+  {
+    http_response_code($component['code']); // Internal Server Error
+    echo json_encode($component);
+    return;
+  }
+  
+  $pricing = get_pricing_data($component['componentId']);
+  if(@$pricing['error'])
+  {
+    http_response_code($pricing['code']); // Internal Server Error
+    echo json_encode($component);
+    return;
+  }
+  
+  echo json_encode([ 'code' => 200, 'errpr' => null, 'data' => array_merge($component,$pricing) ], JSON_PRETTY_PRINT);
+?>
+

--- a/contrib/details-by-part.php
+++ b/contrib/details-by-part.php
@@ -226,6 +226,6 @@
     return;
   }
   
-  echo json_encode([ 'code' => 200, 'errpr' => null, 'data' => array_merge($component,$pricing) ], JSON_PRETTY_PRINT);
+  echo json_encode([ 'code' => 200, 'error' => null, 'data' => array_merge($component,$pricing) ], JSON_PRETTY_PRINT);
 ?>
 

--- a/web/src/componentTable.js
+++ b/web/src/componentTable.js
@@ -706,7 +706,7 @@ function ExpandedComponent(props) {
             <table className="w-full border-b-2">
                 <thead className="border-b-2 font-bold">
                     <tr>
-                        <td>Quantity</td>
+                        <td className="md:w-2/5">Quantity</td>
                         <td>Unit Price</td>
                     </tr>
                 </thead>

--- a/web/src/jlc.js
+++ b/web/src/jlc.js
@@ -101,7 +101,7 @@ export class AttritionInfo extends React.Component {
                           </tr>
                           <tr>
                             <td className="md:w-2/5">Total Price for {this.props.quantity} pcs:</td>
-                            <td>{Math.round((3 + this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
+                            <td>{Math.round((0 + this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
                           </tr>
                           <tr>
                             <td className="md:w-2/5 font-bold">Total Per Piece for {this.props.quantity} pcs:</td>

--- a/web/src/jlc.js
+++ b/web/src/jlc.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { InlineSpinbox } from "./componentTable.js"
-import { CORS_KEY } from "./corsBridge.js";
 
 export function getQuantityPrice(quantity, pricelist) {
     return pricelist.find(pricepoint =>
@@ -16,43 +15,10 @@ export class AttritionInfo extends React.Component {
     }
 
     componentDidMount() {
-        fetch("https://cors.bridged.cc/https://jlcpcb.com/shoppingCart/smtGood/selectSmtComponentList", {
-            method: 'POST',
-            headers: {
-                "Accept": 'application/json, text/plain, */*',
-                "Content-Type": 'application/json;charset=UTF-8',
-                "x-cors-grida-api-key": CORS_KEY
-            },
-            body: JSON.stringify({
-                currentPage: 1,
-                pageSize: 25,
-                keyword: this.props.component.lcsc,
-                firstSortName: "",
-                secondeSortName: "",
-                searchSource: "search",
-                componentAttributes: []
-            })
-        })
+        fetch("https://sparks.gogo.co.nz/jlc/details-by-part.php?partNumber="+this.props.component.lcsc, { })
         .then(response => {
             if (!response.ok || response.status !== 200) {
                 throw new Error(`Cannot fetch ${this.props.component.lcsc}: ${response.statusText}`);
-            }
-            return response.json();
-        })
-        .then(({data}) => {
-            const lcscId = data.componentPageInfo.list.find(({componentCode}) => componentCode === this.props.component.lcsc)?.componentId;
-            if (lcscId === undefined) {
-                throw new Error(`No search results for ${this.props.component.lcsc}`);
-            }
-            return fetch("https://cors.bridged.cc/https://jlcpcb.com/shoppingCart/smtGood/getComponentDetail?componentLcscId=" + lcscId, {
-                headers: {
-                    "x-cors-grida-api-key": CORS_KEY
-                },
-            });
-        })
-        .then(response => {
-            if (!response.ok || response.status !== 200) {
-                throw new Error(`Cannot fetch ${this.props.lcsc}: ${response.statusText}`);
             }
             return response.json();
         })
@@ -81,24 +47,89 @@ export class AttritionInfo extends React.Component {
         if (data)
             return <table className="w-full">
                 <tbody>
-                { data.lossNumber
-                    ? <tr>
-                        <td className="w-1 whitespace-no-wrap">Attrition:</td>
-                        <td className="px-2">{data.lossNumber} pcs</td>
-                      </tr>
-                    : ""
+                    <tr className="border-b-2 font-bold">
+                       <td className="md:w-5/5 pt-4" colSpan="2">Minimums</td>
+                    </tr>   
+                    <tr>
+                      <td className="md:w-2/5">Minimum Order Quantity:</td>
+                      <td>{data.leastNumber?data.leastNumber:0} pcs</td>
+                    </tr>
+                    <tr>
+                      <td className="md:w-2/5">Attrition:</td>
+                      <td>{data.lossNumber?data.lossNumber:0} pcs</td>
+                    </tr>
+                { (data.componentLibraryType === 'expand' && !data.preferredComponentFlag)
+                    ? <React.Fragment>
+                          <tr className="border-b-2 font-bold">
+                            <td className="md:w-5/5 pt-4" colSpan="2">Economic PCBA</td>
+                          </tr>   
+                          <tr>
+                            <td className="md:w-2/5">Loading Fee:</td>
+                            <td>3.00 USD (Extended Part)</td>    
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5">Total Price for {this.props.quantity} pcs:</td>
+                            <td>{Math.round((3 + this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5 font-bold">Total Per Piece for {this.props.quantity} pcs:</td>
+                            <td><strong>{Math.round(((3 + this.price() + Number.EPSILON)/this.props.quantity) * 1000) / 1000} USD</strong></td>
+                          </tr>
+                          <tr className="border-b-2 font-bold">
+                            <td className="md:w-5/5 pt-4" colSpan="2">Standard PCBA</td>
+                          </tr>   
+                          <tr>
+                            <td className="md:w-2/5">Loading Fee:</td>
+                            <td>1.50 USD (Extended Part)</td>    
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5">Total Price for {this.props.quantity} pcs:</td>
+                            <td>{Math.round((1.5 + this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5">Total Per Piece for {this.props.quantity} pcs:</td>
+                            <td>{Math.round(((1.5 + this.price() + Number.EPSILON)/this.props.quantity) * 1000) / 1000} USD</td>
+                          </tr>
+                      </React.Fragment>
+                    : <React.Fragment>
+                          <tr className="border-b-2 font-bold">
+                            <td className="md:w-5/5 pt-4" colSpan="2">Economic PCBA</td>
+                          </tr>   
+                          <tr>
+                            <td className="md:w-2/5">Loading Fee:</td>
+                            <td>None (Basic/Preferred Part)</td>    
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5">Total Price for {this.props.quantity} pcs:</td>
+                            <td>{Math.round((3 + this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5 font-bold">Total Per Piece for {this.props.quantity} pcs:</td>
+                            <td><strong>{Math.round(((0 + this.price() + Number.EPSILON)/this.props.quantity) * 1000) / 1000} USD</strong></td>
+                          </tr>
+                          <tr className="border-b-2 font-bold">
+                            <td className="md:w-5/5 pt-4" colSpan="2">Standard PCBA</td>
+                          </tr>   
+                          <tr>
+                            <td className="md:w-2/5">Loading Fee:</td>
+                            <td>1.50 (Basic/Preferred Part)</td>    
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5">Total Price for {this.props.quantity} pcs:</td>
+                            <td>{Math.round((1.5 + this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
+                          </tr>
+                          <tr>
+                            <td className="md:w-2/5">Total Per Piece for {this.props.quantity} pcs:</td>
+                            <td>{Math.round(((1.5 + this.price() + Number.EPSILON)/this.props.quantity) * 1000) / 1000} USD</td>
+                          </tr>
+                      </React.Fragment>
                 }
-                { data.leastNumber
-                    ? <tr>
-                        <td className="w-1 whitespace-no-wrap">Minimal order quantity:</td>
-                        <td className="px-2">{data.leastNumber} pcs</td>
-                      </tr>
-                    : ""
-                }
-                <tr>
-                    <td className="w-1 whitespace-no-wrap">Price for {this.props.quantity} pcs:</td>
-                    <td className="px-2">{Math.round((this.price() + Number.EPSILON) * 1000) / 1000} USD</td>
-                </tr>
+                  <tr>
+                    <td className="md:w-5/5 border-2 pt-4" colSpan="2">
+                       <p><small>Prices do not include soldering fees, subject to change.</small></p>
+                       <p><small>Total = max( Qty+Attrition, MinimumOrderQty ) * UnitPrice + LoadingFee</small></p>
+                    </td>    
+                  </tr>
                 </tbody>
             </table>
         return <div className="w-full p-4 text-center">


### PR DESCRIPTION
There were a number of problems preventing the existing code from working.

  1. Changes at the JLC website relocating APIs
  2. The CORS proxy that was in use was no longer able to request from JLC
  3. The way the JLC search works requires several different searches to be sure to find components

A simple PHP script has been written to accept a part number (C....) and perform the required search requests to the JLC website, returning the component details as JSON.  This is included in the contrib directory, a copy of this is currently running on one of my servers and the jlc.js has been pointed to it.

The loading fee for parts (as of writing, $3.00 USD for extended parts in Economical PCBA, and $1.50 for both basic/preferred and extended parts in Standard PCBA) has been added to the display and incorporated in the total and amortised total per-piece prices.

A note has been added to indicate how the total is calculated to make it clear how the attrition factors into the equation.

HTML adjustments have been made for aesthetic reasons.



See dougy83/jlcparts#7